### PR TITLE
Switch to vbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Increase allocated memory
 - Use vbase instead of MasterData
+- Change download tax route to private
 
 ## [0.0.5] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Increase allocated memory
+- Use vbase instead of MasterData
+
 ## [0.0.5] - 2022-07-27
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,9 @@
       "name": "ADMIN_DS"
     },
     {
+      "name": "vbase-read-write"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "api.vtex.com",

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,5 +1,7 @@
 export const FALLBACK_ENTITY_PREFIX = 'taxFallback_'
 export const SUPPORTED_PROVIDERS = ['avalara']
+export const TAX_UPDATE_EVENT = 'taxFallback.taxUpdate'
+export const VBASE_BUCKET = 'tax-fallback'
 
 export const MS_PER_DAY = 1000 * 60 * 60 * 24
 export const DAYS_TO_TRIGGER_DOWNLOAD = 28

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -2,6 +2,7 @@ export const FALLBACK_ENTITY_PREFIX = 'taxFallback_'
 export const SUPPORTED_PROVIDERS = ['avalara']
 export const TAX_UPDATE_EVENT = 'taxFallback.taxUpdate'
 export const VBASE_BUCKET = 'tax-fallback'
+export const AVALARA_LOCK_PATH = 'avalara-lock'
 
 export const MS_PER_DAY = 1000 * 60 * 60 * 24
 export const DAYS_TO_TRIGGER_DOWNLOAD = 28

--- a/node/middlewares/throttle.ts
+++ b/node/middlewares/throttle.ts
@@ -1,0 +1,18 @@
+import { TooManyRequestsError } from '@vtex/api'
+
+const MAX_REQUEST = 10
+let COUNTER = 0
+
+export async function throttle(_ctx: EventCtx, next: () => Promise<unknown>) {
+  COUNTER++
+
+  try {
+    if (COUNTER > MAX_REQUEST) {
+      throw new TooManyRequestsError()
+    }
+
+    await next()
+  } finally {
+    COUNTER--
+  }
+}

--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
     "@types/tiny-async-pool": "^1.0.0",
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.45.12",
     "@vtex/test-tools": "^1.0.0",
     "typescript": "3.9.7"
   },

--- a/node/service.json
+++ b/node/service.json
@@ -1,9 +1,9 @@
 {
-  "memory": 256,
+  "memory": 512,
   "ttl": 60,
-  "timeout": 10,
+  "timeout": 30,
   "minReplicas": 2,
-  "maxReplicas": 4,
+  "maxReplicas": 10,
   "workers": 1,
   "routes": {
     "getFallbackTaxes": {
@@ -13,6 +13,12 @@
     "downloadFallbackTaxes": {
       "path": "/_v/tax-fallback/download-taxes/:country/:provider",
       "public": true
+    }
+  },
+  "events": {
+    "taxUpdate": {
+      "sender": "vtex.tax-fallback",
+      "keys": ["taxFallback.taxUpdate"]
     }
   }
 }

--- a/node/service.json
+++ b/node/service.json
@@ -11,8 +11,8 @@
       "public": true
     },
     "downloadFallbackTaxes": {
-      "path": "/_v/tax-fallback/download-taxes/:country/:provider",
-      "public": true
+      "path": "/_v/download-taxes/:country/:provider",
+      "public": false
     }
   },
   "events": {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1248,10 +1248,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.45.12":
+  version "6.45.12"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
+  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1260,7 +1260,7 @@
     agentkeepalive "^4.0.2"
     apollo-server-errors "^2.2.1"
     archiver "^3.0.0"
-    axios "^0.19.2"
+    axios "^0.21.1"
     axios-retry "^3.1.2"
     bluebird "^3.5.4"
     chalk "^2.4.2"
@@ -1290,6 +1290,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    tokenbucket "^0.3.2"
     uuid "^3.3.3"
     xss "^1.0.6"
 
@@ -1679,12 +1680,12 @@ axios-retry@^3.1.2:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.14.0"
 
 babel-jest@^24.4.0, babel-jest@^24.9.0:
   version "24.9.0"
@@ -1777,6 +1778,11 @@ bl@^3.0.0:
   integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
   dependencies:
     readable-stream "^3.0.1"
+
+bluebird@2.9.24:
+  version "2.9.24"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.24.tgz#14a2e75f0548323dc35aa440d92007ca154e967c"
+  integrity sha512-F6vWSDdJRZ5mKeycWf7+l81ibpnjRtQz26eBTUxjpet9tUpN0rz+TV6uO0CCySHdtW4dDZNBSqbbMKoxPChqYw==
 
 bluebird@^3.5.4:
   version "3.7.2"
@@ -2200,12 +2206,6 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
-debug@=3.1.0, debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  dependencies:
-    ms "2.0.0"
-
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2226,6 +2226,12 @@ debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -2583,12 +2589,10 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
+follow-redirects@^1.14.0:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -4813,6 +4817,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-0.12.1.tgz#64df76ad0fc8acebaebd2a0645e8a48fac49185e"
+  integrity sha512-DtqxdmgmVAO7aEyxaXBiUTvhQPOYznTIvmPzs9AwWZqZywM50JlFxQjFhicI+LVbaun7uwfO3izuvc1L8NlPKQ==
+
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
@@ -5504,6 +5513,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tokenbucket@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tokenbucket/-/tokenbucket-0.3.2.tgz#8172b2b58e3083acc8d914426fed15162a3a8e90"
+  integrity sha512-w0rTsBITjZfssjMh9xaBoQjf1Nx4/F0qPKqPzEB05SyOiAwoCCqGHl332H41LFAVonHMCWCnm3R8tvenjOBd8A==
+  dependencies:
+    bluebird "2.9.24"
+    redis "^0.12.1"
 
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"


### PR DESCRIPTION
The masterdata tax-fallback index in `vtexus` has grown absurdly large because a bug was causing the app to create new documents each time the taxes were updated, instead of updating the existing documents. 

Reviewing the app, it made more sense to switch to vbase -- now, each postal code will be a separate vbase file, one file per postal code, and when taxes are updated, it will update the appropriate file instead of creating a new one.

The new app is linked here: https://arthur--vtexus.myvtex.com

Test in Postman by getting https://arthur--vtexus.myvtex.com/_v/tax-fallback/USA/avalara/14611